### PR TITLE
Add capability to consume temporary GKE clusters for cloud integration

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -528,8 +528,124 @@ jobs:
         bin/docker-retag-all $TAG master
         bin/docker-push master
 
-  cloud_integration:
-    name: Cloud integration tests
+  # cloud_integration:
+  #   name: Cloud integration tests
+  #   runs-on: ubuntu-18.04
+  #   needs: [docker_deploy]
+  #   steps:
+  #   - name: Download .git artifact
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: linkerd2-src-${{ github.sha }}
+  #       path: ${{ runner.temp }}
+  #   - name: Clone source
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     run: |
+  #       tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
+  #       git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
+  #   - name: Configure gcloud
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     env:
+  #       CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+  #       CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+  #       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+  #       GCP_ZONE: ${{ secrets.GCP_ZONE }}
+  #       GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
+  #     run: |
+  #       # Install gcloud and kubectl.
+  #       echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
+  #       dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+  #       (
+  #         . bin/_gcp.sh ;
+  #         install_gcloud "$dir"
+  #         gcloud components install kubectl
+  #         # Configure gcloud with a service account.
+  #         set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+  #         # Get a kubernetes context.
+  #         get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+  #       )
+  #       . "$dir/path.bash.inc"
+  #       gcloud auth configure-docker
+  #       bin/kubectl version --short
+  #   - name: Install linkerd CLI
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     run: |
+  #       TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+  #       image="gcr.io/linkerd-io/cli-bin:$TAG"
+  #       id=$(bin/docker create $image)
+  #       bin/docker cp "$id:/out/linkerd-linux" "$HOME/.linkerd"
+  #       $HOME/.linkerd version --client
+  #       # validate CLI version matches the repo
+  #       [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
+  #       echo "Installed Linkerd CLI version: $TAG"
+  #   - name: Run integration tests
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     env:
+  #       GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+  #     run: |
+  #       export PATH="`pwd`/bin:$PATH"
+  #       echo "$GITCOOKIE_SH" | bash
+  #       version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
+  #       bin/test-run $HOME/.linkerd linkerd-$version
+  #   - name: CNI tests
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     run: |
+  #       export TAG="$($HOME/.linkerd version --client --short)"
+  #       go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+
+  # cloud_cleanup:
+  #   if: always()
+  #   name: Cloud cleanup
+  #   runs-on: ubuntu-18.04
+  #   needs: [cloud_integration]
+  #   steps:
+  #   - name: Download .git artifact
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     uses: actions/download-artifact@v1
+  #     with:
+  #       name: linkerd2-src-${{ github.sha }}
+  #       path: ${{ runner.temp }}
+  #   - name: Clone source
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     run: |
+  #       tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
+  #       git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
+  #   - name: Configure gcloud
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     env:
+  #       CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+  #       CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+  #       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+  #       GCP_ZONE: ${{ secrets.GCP_ZONE }}
+  #       GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
+  #     run: |
+  #       # Install gcloud and kubectl.
+  #       echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
+  #       dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+  #       (. bin/_gcp.sh ;
+  #         install_gcloud "$dir"
+  #         gcloud components install kubectl
+  #         # Configure gcloud with a service account.
+  #         set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+  #         # Get a kubernetes context.
+  #         get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+  #       )
+  #       . "$dir/path.bash.inc"
+  #       gcloud auth configure-docker
+  #       bin/kubectl version --short
+  #   - name: Cleanup
+  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+  #     run: |
+  #       export PATH="`pwd`/bin:$PATH"
+  #       bin/test-cleanup
+
+  gcp_cloud_integration:
+    strategy:
+      fail-fast: false # always attempt to cleanup all clusters
+      matrix:
+        cloud_integration_test: [deep, upgrade, helm, custom_domain]
+    name: GCP Cloud integration tests (${{ matrix.cloud_integration_test }})
     runs-on: ubuntu-18.04
     needs: [docker_deploy]
     steps:
@@ -544,24 +660,32 @@ jobs:
       run: |
         tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
         git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
-    - name: Configure gcloud
+    - name: Configure gcloud and spawn temporary K8s cluster
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
       env:
         CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
         CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
         GCP_ZONE: ${{ secrets.GCP_ZONE }}
-        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
       run: |
         # Install gcloud and kubectl.
         echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
         dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+        # Flagging current cloud 
+        target_cloud="gcp"
+        # Creating a unique name for this commit
+        export GKE_CLUSTER=${{ matrix.cloud_integration_test }}-${$GITHUB_SHA::6}
         (
           . bin/_gcp.sh ;
           install_gcloud "$dir"
           gcloud components install kubectl
           # Configure gcloud with a service account.
-          set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+          set_gcloud_project "$GCP_PROJECT" "$GCP_ZONE"
+          # Loading cluster config from project
+          k8s_version=$(get_default_k8s_version)
+          . test/testdata/cloud_config/"${target_cloud}/${{ matrix.cloud_integration_test }}.conf" ;
+          # Spawn a new cluster
+          create_cluster "${GKE_CLUSTER}" "${k8s_version}" "${cluster_size}" "${machine_type}"
           # Get a kubernetes context.
           get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
         )
@@ -594,11 +718,15 @@ jobs:
         export TAG="$($HOME/.linkerd version --client --short)"
         go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
 
-  cloud_cleanup:
+  gcp_cloud_cleanup:
     if: always()
-    name: Cloud cleanup
+    strategy:
+      fail-fast: false # always attempt to cleanup all clusters
+      matrix:
+        cloud_integration_test: [deep, upgrade, helm, custom_domain]
+    name: GCP Cloud Cleanup (${{ matrix.cloud_integration_test }})
     runs-on: ubuntu-18.04
-    needs: [cloud_integration]
+    needs: [gcp_cloud_integration]
     steps:
     - name: Download .git artifact
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
@@ -611,34 +739,27 @@ jobs:
       run: |
         tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
         git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
-    - name: Configure gcloud
+    - name: Configure gcloud and cleanup temporary K8s cluster
       if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
       env:
         CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
         CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
         GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
         GCP_ZONE: ${{ secrets.GCP_ZONE }}
-        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
       run: |
         # Install gcloud and kubectl.
         echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
         dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+        # Creating a unique name for this commit
+        export GKE_CLUSTER=${{ matrix.cloud_integration_test }}-${$GITHUB_SHA::6}
         (. bin/_gcp.sh ;
           install_gcloud "$dir"
           gcloud components install kubectl
           # Configure gcloud with a service account.
           set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
-          # Get a kubernetes context.
-          get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+          # Cleanup Cluster
+          destroy_cluster "$GKE_CLUSTER"
         )
-        . "$dir/path.bash.inc"
-        gcloud auth configure-docker
-        bin/kubectl version --short
-    - name: Cleanup
-      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-      run: |
-        export PATH="`pwd`/bin:$PATH"
-        bin/test-cleanup
 
   #
   # Helm chart artifact deploy run for:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -528,117 +528,117 @@ jobs:
         bin/docker-retag-all $TAG master
         bin/docker-push master
 
-  # cloud_integration:
-  #   name: Cloud integration tests
-  #   runs-on: ubuntu-18.04
-  #   needs: [docker_deploy]
-  #   steps:
-  #   - name: Download .git artifact
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: linkerd2-src-${{ github.sha }}
-  #       path: ${{ runner.temp }}
-  #   - name: Clone source
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     run: |
-  #       tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
-  #       git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
-  #   - name: Configure gcloud
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     env:
-  #       CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
-  #       CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
-  #       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
-  #       GCP_ZONE: ${{ secrets.GCP_ZONE }}
-  #       GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-  #     run: |
-  #       # Install gcloud and kubectl.
-  #       echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
-  #       dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
-  #       (
-  #         . bin/_gcp.sh ;
-  #         install_gcloud "$dir"
-  #         gcloud components install kubectl
-  #         # Configure gcloud with a service account.
-  #         set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
-  #         # Get a kubernetes context.
-  #         get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
-  #       )
-  #       . "$dir/path.bash.inc"
-  #       gcloud auth configure-docker
-  #       bin/kubectl version --short
-  #   - name: Install linkerd CLI
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     run: |
-  #       TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
-  #       image="gcr.io/linkerd-io/cli-bin:$TAG"
-  #       id=$(bin/docker create $image)
-  #       bin/docker cp "$id:/out/linkerd-linux" "$HOME/.linkerd"
-  #       $HOME/.linkerd version --client
-  #       # validate CLI version matches the repo
-  #       [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
-  #       echo "Installed Linkerd CLI version: $TAG"
-  #   - name: Run integration tests
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     env:
-  #       GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
-  #     run: |
-  #       export PATH="`pwd`/bin:$PATH"
-  #       echo "$GITCOOKIE_SH" | bash
-  #       version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
-  #       bin/test-run $HOME/.linkerd linkerd-$version
-  #   - name: CNI tests
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     run: |
-  #       export TAG="$($HOME/.linkerd version --client --short)"
-  #       go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
+  cloud_integration:
+    name: Cloud integration tests
+    runs-on: ubuntu-18.04
+    needs: [docker_deploy]
+    steps:
+    - name: Download .git artifact
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      uses: actions/download-artifact@v1
+      with:
+        name: linkerd2-src-${{ github.sha }}
+        path: ${{ runner.temp }}
+    - name: Clone source
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      run: |
+        tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
+        git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
+    - name: Configure gcloud
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      env:
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+        CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+        GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+        GCP_ZONE: ${{ secrets.GCP_ZONE }}
+        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
+      run: |
+        # Install gcloud and kubectl.
+        echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
+        dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+        (
+          . bin/_gcp.sh ;
+          install_gcloud "$dir"
+          gcloud components install kubectl
+          # Configure gcloud with a service account.
+          set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+          # Get a kubernetes context.
+          get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+        )
+        . "$dir/path.bash.inc"
+        gcloud auth configure-docker
+        bin/kubectl version --short
+    - name: Install linkerd CLI
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      run: |
+        TAG="$(CI_FORCE_CLEAN=1 bin/root-tag)"
+        image="gcr.io/linkerd-io/cli-bin:$TAG"
+        id=$(bin/docker create $image)
+        bin/docker cp "$id:/out/linkerd-linux" "$HOME/.linkerd"
+        $HOME/.linkerd version --client
+        # validate CLI version matches the repo
+        [[ "$TAG" == "$($HOME/.linkerd version --short --client)" ]]
+        echo "Installed Linkerd CLI version: $TAG"
+    - name: Run integration tests
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      env:
+        GITCOOKIE_SH: ${{ secrets.GITCOOKIE_SH }}
+      run: |
+        export PATH="`pwd`/bin:$PATH"
+        echo "$GITCOOKIE_SH" | bash
+        version="$($HOME/.linkerd version --client --short | tr -cd '[:alnum:]-')"
+        bin/test-run $HOME/.linkerd linkerd-$version
+    - name: CNI tests
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      run: |
+        export TAG="$($HOME/.linkerd version --client --short)"
+        go test -cover -race -v -mod=readonly ./cni-plugin/test -integration-tests
 
-  # cloud_cleanup:
-  #   if: always()
-  #   name: Cloud cleanup
-  #   runs-on: ubuntu-18.04
-  #   needs: [cloud_integration]
-  #   steps:
-  #   - name: Download .git artifact
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     uses: actions/download-artifact@v1
-  #     with:
-  #       name: linkerd2-src-${{ github.sha }}
-  #       path: ${{ runner.temp }}
-  #   - name: Clone source
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     run: |
-  #       tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
-  #       git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
-  #   - name: Configure gcloud
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     env:
-  #       CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
-  #       CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
-  #       GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
-  #       GCP_ZONE: ${{ secrets.GCP_ZONE }}
-  #       GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
-  #     run: |
-  #       # Install gcloud and kubectl.
-  #       echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
-  #       dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
-  #       (. bin/_gcp.sh ;
-  #         install_gcloud "$dir"
-  #         gcloud components install kubectl
-  #         # Configure gcloud with a service account.
-  #         set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
-  #         # Get a kubernetes context.
-  #         get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
-  #       )
-  #       . "$dir/path.bash.inc"
-  #       gcloud auth configure-docker
-  #       bin/kubectl version --short
-  #   - name: Cleanup
-  #     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
-  #     run: |
-  #       export PATH="`pwd`/bin:$PATH"
-  #       bin/test-cleanup
+  cloud_cleanup:
+    if: always()
+    name: Cloud cleanup
+    runs-on: ubuntu-18.04
+    needs: [cloud_integration]
+    steps:
+    - name: Download .git artifact
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      uses: actions/download-artifact@v1
+      with:
+        name: linkerd2-src-${{ github.sha }}
+        path: ${{ runner.temp }}
+    - name: Clone source
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      run: |
+        tar -C $RUNNER_TEMP -zxf $RUNNER_TEMP/linkerd2.$GITHUB_SHA.tar.gz
+        git clone $RUNNER_TEMP/.git $GITHUB_WORKSPACE
+    - name: Configure gcloud
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      env:
+        CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+        CLOUD_SDK_SERVICE_ACCOUNT_KEY: ${{ secrets.CLOUD_SDK_SERVICE_ACCOUNT_KEY }}
+        GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+        GCP_ZONE: ${{ secrets.GCP_ZONE }}
+        GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
+      run: |
+        # Install gcloud and kubectl.
+        echo "$CLOUD_SDK_SERVICE_ACCOUNT_KEY" > .gcp.json
+        dir="${CLOUDSDK_INSTALL_DIR:-${HOME}}/google-cloud-sdk"
+        (. bin/_gcp.sh ;
+          install_gcloud "$dir"
+          gcloud components install kubectl
+          # Configure gcloud with a service account.
+          set_gcloud_config "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+          # Get a kubernetes context.
+          get_k8s_ctx "$GCP_PROJECT" "$GCP_ZONE" "$GKE_CLUSTER"
+        )
+        . "$dir/path.bash.inc"
+        gcloud auth configure-docker
+        bin/kubectl version --short
+    - name: Cleanup
+      if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+      run: |
+        export PATH="`pwd`/bin:$PATH"
+        bin/test-cleanup
 
   gcp_cloud_integration:
     strategy:

--- a/bin/_gcp.sh
+++ b/bin/_gcp.sh
@@ -14,14 +14,22 @@ install_gcloud() {
     fi
 }
 
+set_gcloud_project() {
+    # Switches to a new project or exits if called on the same project
+    project="$1"
+    zone="$2"
+
+    gcloud config set core/project "$project"
+    gcloud config set compute/zone "$zone"
+}
+
 set_gcloud_config() {
     project="$1"
     zone="$2"
     cluster="$3"
 
     gcloud auth activate-service-account --key-file .gcp.json
-    gcloud config set core/project "$project"
-    gcloud config set compute/zone "$zone"
+    set_gcloud_project "$project" "$zone"
     gcloud config set container/cluster "$cluster"
 }
 
@@ -36,5 +44,42 @@ get_k8s_ctx() {
         fi
     done
 
-    gcloud container clusters get-credentials "$cluster"
+    gcloud container clusters get-credentials -q "$cluster"
+}
+
+get_available_k8s_versions() {
+    # Returns a ; separated list of valid versions 
+    gcloud container get-server-config --zone=us-central1-f --format="value(validMasterVersions:sort=1)"
+}
+
+get_default_k8s_version() {
+    # Returns the default cluster version available
+    gcloud container get-server-config --zone=us-central1-f --format="value(defaultClusterVersion)"
+}
+
+create_cluster() {
+    cluster="$1"
+    k8s_version="$2"
+    cluster_size="$3"
+    machine_type="$4"
+
+    # Creates a k8s cluster according to a cluster config file
+    gcloud container clusters create "${cluster}" \
+        --cluster-version "${k8s_version}" \
+        --machine-type "${machine_type}" \
+        --num-nodes "${cluster_size}" \
+        --quiet \
+        2>/dev/null
+
+    # This should be a while look instead to make it more robust
+    sleep 5
+
+    # Use this cluster & set creds for k8s
+    get_k8s_ctx "${project}" "${zone}" "${cluster}"
+} 
+
+destroy_cluster() {
+    cluster="$1"
+
+    gcloud container clusters delete -q "${cluster}" 2>/dev/null
 }

--- a/test/testdata/cloud_config/gcp/custom_domain.conf
+++ b/test/testdata/cloud_config/gcp/custom_domain.conf
@@ -1,0 +1,5 @@
+# Cluster Settings
+cluster_name=deep
+cluster_size=3
+machine_type="n1-standard-2"
+k8s_version=1.14.8

--- a/test/testdata/cloud_config/gcp/deep.conf
+++ b/test/testdata/cloud_config/gcp/deep.conf
@@ -1,0 +1,4 @@
+# Cluster Settings
+cluster_size=3
+machine_type="n1-standard-2"
+# k8s_version=1.14.8

--- a/test/testdata/cloud_config/gcp/helm.conf
+++ b/test/testdata/cloud_config/gcp/helm.conf
@@ -1,0 +1,5 @@
+# Cluster Settings
+cluster_name=deep
+cluster_size=3
+machine_type="n1-standard-2"
+k8s_version=1.14.8

--- a/test/testdata/cloud_config/gcp/upgrade.conf
+++ b/test/testdata/cloud_config/gcp/upgrade.conf
@@ -1,0 +1,5 @@
+# Cluster Settings
+cluster_name=deep
+cluster_size=3
+machine_type="n1-standard-2"
+k8s_version=1.14.8


### PR DESCRIPTION
Problem: cloud_integration only supports persistent GKE cluster

Solution: add support for handling lifecycle of GKE clusters

Validation: Various runs of "fake" PRs, Commits and tagging to test all matrix elements

Fixes #3717

Signed-off-by: Samuel Cozannet <samuel.cozannet@madeden.com>
